### PR TITLE
Fix saving when an iOS apps terminates or enters the background

### DIFF
--- a/DCTCoreDataStack.m
+++ b/DCTCoreDataStack.m
@@ -253,16 +253,7 @@ typedef void (^DCTInternalCoreDataStackSaveBlock) (NSManagedObjectContext *manag
 	
 	if (![self.managedObjectContext hasChanges]) return;
 	
-	if ([self.managedObjectContext respondsToSelector:@selector(performBlock:)]) {
-	
-		[self.managedObjectContext performBlock:^{
-			[self.managedObjectContext dct_saveWithCompletionHandler:NULL];
-		}];
-
-	} else {
-		
-		[self.managedObjectContext dct_saveWithCompletionHandler:NULL];
-	}
+    [self.managedObjectContext dct_saveWithCompletionHandler:NULL];
 	
 	// TODO: what if there was a save error?
 }
@@ -271,16 +262,7 @@ typedef void (^DCTInternalCoreDataStackSaveBlock) (NSManagedObjectContext *manag
 	
 	if (![self.managedObjectContext hasChanges]) return;
 	
-	if ([self.managedObjectContext respondsToSelector:@selector(performBlock:)]) {
-		
-		[self.managedObjectContext performBlock:^{
-			[self.managedObjectContext save:nil];
-		}];
-		
-	} else {
-		
-		[self.managedObjectContext save:nil];
-	}
+    [self.managedObjectContext save:nil];
 }
 #endif
 

--- a/DCTCoreDataStack.m
+++ b/DCTCoreDataStack.m
@@ -253,7 +253,16 @@ typedef void (^DCTInternalCoreDataStackSaveBlock) (NSManagedObjectContext *manag
 	
 	if (![self.managedObjectContext hasChanges]) return;
 	
-    [self.managedObjectContext dct_saveWithCompletionHandler:NULL];
+	if ([self.managedObjectContext respondsToSelector:@selector(performBlock:)] && ![NSThread isMainThread]) {
+        
+		[self.managedObjectContext performBlock:^{
+			[self.managedObjectContext dct_saveWithCompletionHandler:NULL];
+		}];
+        
+	} else {
+		
+		[self.managedObjectContext dct_saveWithCompletionHandler:NULL];
+	}
 	
 	// TODO: what if there was a save error?
 }
@@ -262,7 +271,16 @@ typedef void (^DCTInternalCoreDataStackSaveBlock) (NSManagedObjectContext *manag
 	
 	if (![self.managedObjectContext hasChanges]) return;
 	
-    [self.managedObjectContext save:nil];
+	if ([self.managedObjectContext respondsToSelector:@selector(performBlock:)] && ![NSThread isMainThread]) {
+		
+		[self.managedObjectContext performBlock:^{
+			[self.managedObjectContext save:nil];
+		}];
+		
+	} else {
+		
+		[self.managedObjectContext save:nil];
+	}
 }
 #endif
 


### PR DESCRIPTION
Saves were being performed in a block which was unnecessary as the context is a main thread context and the notifications happen on the main thread.

This was preventing the context saving when the app entered the background
