### PR TITLE
Fix "shadowed local variables" warning

### DIFF
--- a/DCTCoreDataStack/_DCTCDSManagedObjectContext.m
+++ b/DCTCoreDataStack/_DCTCDSManagedObjectContext.m
@@ -97,9 +97,9 @@
 		}
 		
 		[parent performBlock:^{
-			[parent dct_saveWithCompletionHandler:^(BOOL success, NSError *error) {
+			[parent dct_saveWithCompletionHandler:^(BOOL parentSuccess, NSError *parentError) {
 				[self performBlock:^{
-					completion(success, error);
+					completion(parentSuccess, parentError);
 				}];
 			}];
 		}];


### PR DESCRIPTION
Otherwise the block to save the parent context will capture the success and error variables from the main context save.
