### PR TITLE
Restore logging if no completion handler given

### DIFF
--- a/DCTCoreDataStack/NSManagedObjectContext+DCTCoreDataStack.m
+++ b/DCTCoreDataStack/NSManagedObjectContext+DCTCoreDataStack.m
@@ -58,8 +58,6 @@
 	
 	if (completionHandler != NULL)
 		completionHandler(success, error);
-	else if (!success)
-		NSLog(@"%@", [self dct_detailedDescriptionFromValidationError:error]);
 }
 
 - (NSString *)dct_detailedDescriptionFromValidationError:(NSError *)anError {

--- a/DCTCoreDataStack/_DCTCDSManagedObjectContext.m
+++ b/DCTCoreDataStack/_DCTCDSManagedObjectContext.m
@@ -66,7 +66,10 @@
 
 - (void)dct_saveWithCompletionHandler:(void(^)(BOOL success, NSError *error))completion {
 
-	if (completion == NULL) completion = ^(BOOL success, NSError *error) {};
+	if (completion == NULL) completion = ^(BOOL success, NSError *error) {
+        if (!success)
+            NSLog(@"%@", [self dct_detailedDescriptionFromValidationError:error]);
+    };
 
 #if TARGET_OS_IPHONE
 	


### PR DESCRIPTION
The logging in `NSManagedObjectContext+DCTCoreDataStack.m` was never called because the override in `_DCTCDSManagedObjectContext` was adding a no-op completion handler if none was passed in.

Moving the logging to the completion handler added by `_DCTCDSManagedObjectContext` fixes this.

(Fix suggested by Daniel Tull)
